### PR TITLE
fix: blog post link; package.json dependency "express"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # istanbul-code-coverage-example
 Example project for istanbul jasmine and supertest integration
 
-Read the full blog-post here
+Read the full blog-post [here](https://medium.com/walkme-engineering/measure-your-nodejs-code-coverage-using-istanbul-82b129c81ae9).
 
 ## Installation
 ```text

--- a/package.json
+++ b/package.json
@@ -14,13 +14,14 @@
   "author": "Tal Kaminsky",
   "license": "MIT",
   "devDependencies": {
-    "jasmine": "^2.8.0",
-    "jasmine-node": "^1.14.5",
     "istanbul": "^0.4.5",
+    "jasmine": "^2.8.0",
     "jasmine-console-reporter": "^2.0.1",
-    "supertest": "^3.0.0",
-    "jasmine-supertest": "^1.0.0"
+    "jasmine-node": "^1.14.5",
+    "jasmine-supertest": "^1.0.0",
+    "supertest": "^3.0.0"
   },
   "dependencies": {
+    "express": "^4.18.2"
   }
 }


### PR DESCRIPTION
Hi,

I recently came to read your [blog post](https://medium.com/walkme-engineering/measure-your-nodejs-code-coverage-using-istanbul-82b129c81ae9) and found this repo. I am curious about how Istanbul works and how it could be used for computing code coverage, so I navigated into your repo.

When I tried to run the code it comes to my attention that the `express` dependency package was not listed in `package.json`. So I raised this MR to add it into the `package.json` file.

Also the link to your blog post was missing from the `README.md` file so I also added it here.

Thanks!